### PR TITLE
feat(F): drop placeholder line during drag

### DIFF
--- a/packages/artifact/src/components/Column.tsx
+++ b/packages/artifact/src/components/Column.tsx
@@ -94,6 +94,13 @@ export function Column({
       </header>
 
       <div className="cowork-scroll flex flex-1 flex-col gap-1.5 overflow-y-auto p-2">
+        {isOver && (
+          <div
+            aria-hidden
+            data-testid="drop-placeholder-column"
+            className="drop-placeholder"
+          />
+        )}
         {children}
 
         {adding && (

--- a/packages/artifact/src/components/TaskCard.tsx
+++ b/packages/artifact/src/components/TaskCard.tsx
@@ -117,6 +117,14 @@ export function TaskCard({
       : { ...draggable.attributes, ...draggable.listeners };
 
   return (
+    <>
+      {isDropOver && !previewMode && !isDragging && (
+        <div
+          aria-hidden
+          data-testid="drop-placeholder"
+          className="drop-placeholder"
+        />
+      )}
     <article
       ref={setRefs}
       style={style}
@@ -263,5 +271,6 @@ export function TaskCard({
         </div>
       )}
     </article>
+    </>
   );
 }

--- a/packages/artifact/src/styles.css
+++ b/packages/artifact/src/styles.css
@@ -419,3 +419,19 @@ input[type='date']:hover::-webkit-calendar-picker-indicator {
   white-space: pre-wrap;
   margin: 0;
 }
+
+/* ─── Drop placeholder ─────────────────────────────────────────────────
+ * Thin accent line that shows where a dragged card will land.
+ * Rendered above any card whose droppable is being hovered. */
+.drop-placeholder {
+  height: 2px;
+  margin: -1px 0;
+  background: var(--accent);
+  border-radius: 2px;
+  box-shadow: 0 0 0 2px color-mix(in oklab, var(--accent) 25%, transparent);
+  animation: drop-pulse 1.4s ease-in-out infinite;
+}
+@keyframes drop-pulse {
+  0%, 100% { opacity: 0.65; }
+  50%      { opacity: 1; }
+}


### PR DESCRIPTION
## Phase F

Shows a 2px terracotta accent line where a dragged card will land - above the hovered card, or at the top of an empty column. Subtle pulse so it reads as 'active drop zone' without noise.

## Test plan
- [x] Build green
- [ ] Visual smoke after merge in Cowork