### PR TITLE
feat(D): add column / rename column

### DIFF
--- a/packages/artifact/src/App.tsx
+++ b/packages/artifact/src/App.tsx
@@ -26,7 +26,7 @@ function genId(): string {
 }
 
 export function App() {
-  const config = useConfig();
+  const { config, renameColumn, addColumn } = useConfig();
   const { tasks, version, newlyAdded, refresh, loading, setTasksLocal, resetToSnapshot } =
     useTasks(2000);
   const [search, setSearch] = useState('');
@@ -353,6 +353,7 @@ export function App() {
                     column={column}
                     count={cards.length}
                     onAddTask={(title) => handleAddTask(column.id, title)}
+                    onRename={renameColumn}
                     autoOpen={pendingNewTask === column.id}
                     onAutoOpenConsumed={() => setPendingNewTask(null)}
                   >
@@ -376,6 +377,7 @@ export function App() {
                   </Column>
                 );
               })}
+              <AddColumnSlot onAdd={addColumn} />
               <DragOverlay dropAnimation={null} zIndex={9999}>
                 {dragging ? (
                   <div className="rotate-1 opacity-95">
@@ -419,6 +421,81 @@ export function App() {
       </footer>
 
       {showHelp && <HelpDialog onClose={() => setShowHelp(false)} />}
+    </div>
+  );
+}
+
+// ─────────────────────────── Add column slot ────────────────────────────────
+
+import { useEffect as _useEffectAddCol, useRef as _useRefAddCol, useState as _useStateAddCol } from 'react';
+import { Plus as PlusIconAddCol } from 'lucide-react';
+
+function AddColumnSlot({ onAdd }: { onAdd: (name: string) => void }) {
+  const [opening, setOpening] = _useStateAddCol(false);
+  const [draft, setDraft] = _useStateAddCol('');
+  const ref = _useRefAddCol<HTMLInputElement>(null);
+
+  _useEffectAddCol(() => {
+    if (opening) ref.current?.focus();
+  }, [opening]);
+
+  const submit = () => {
+    const name = draft.trim();
+    if (name) onAdd(name);
+    setDraft('');
+    setOpening(false);
+  };
+
+  if (!opening) {
+    return (
+      <button
+        type="button"
+        onClick={() => setOpening(true)}
+        data-testid="add-column-button"
+        aria-label="Add a new column"
+        className="flex h-full min-w-[200px] flex-col items-center justify-center gap-1 rounded-lg border border-dashed border-line bg-canvas/40 px-3 py-6 font-display text-[13px] text-soft transition-colors hover:border-line-strong hover:bg-paper hover:text-ink"
+      >
+        <PlusIconAddCol size={16} strokeWidth={1.6} />
+        New column
+      </button>
+    );
+  }
+
+  return (
+    <div
+      data-testid="add-column-form"
+      className="flex h-full min-w-[230px] flex-col rounded-lg border border-accent/40 bg-canvas px-3 py-3 shadow-sm"
+    >
+      <label className="font-display text-2xs font-semibold uppercase tracking-wider text-soft">
+        New column
+      </label>
+      <input
+        ref={ref}
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            e.preventDefault();
+            submit();
+          } else if (e.key === 'Escape') {
+            e.preventDefault();
+            setDraft('');
+            setOpening(false);
+          }
+        }}
+        onBlur={() => {
+          if (!draft.trim()) {
+            setOpening(false);
+            setDraft('');
+          } else {
+            submit();
+          }
+        }}
+        placeholder="Column name"
+        data-testid="add-column-input"
+        className="mt-2 w-full bg-canvas font-display text-md text-ink outline-none ring-1 ring-line-strong rounded-sm px-2 py-1 focus:ring-accent/40"
+      />
+      <span className="mt-2 font-mono text-2xs text-faint">⏎ add · Esc cancel</span>
     </div>
   );
 }

--- a/packages/artifact/src/api.ts
+++ b/packages/artifact/src/api.ts
@@ -418,6 +418,14 @@ export const api = {
       ],
     };
   },
+
+  updateConfig: async (patch: Partial<Config>): Promise<Config | null> => {
+    if (getDataSource() === 'mcp') {
+      const out = await safe(callMcp<Config>('update_config', { patch }));
+      if (out) return out;
+    }
+    return null; // best-effort - local state is already updated optimistically
+  },
 };
 
 /** Send a prompt back to Claude Cowork's chat. */

--- a/packages/artifact/src/components/Column.tsx
+++ b/packages/artifact/src/components/Column.tsx
@@ -1,5 +1,5 @@
 import { useDroppable } from '@dnd-kit/core';
-import { useEffect, useState, type ReactNode } from 'react';
+import { useEffect, useRef, useState, type ReactNode } from 'react';
 import { Plus } from 'lucide-react';
 import type { Column as ColumnType } from '../types';
 
@@ -8,6 +8,8 @@ interface ColumnProps {
   count: number;
   children: ReactNode;
   onAddTask?: (title: string) => void;
+  /** Rename the column. Triggered by double-click on the header label. */
+  onRename?: (id: string, name: string) => void;
   autoOpen?: boolean;
   onAutoOpenConsumed?: () => void;
 }
@@ -17,12 +19,41 @@ export function Column({
   count,
   children,
   onAddTask,
+  onRename,
   autoOpen,
   onAutoOpenConsumed,
 }: ColumnProps) {
   const { isOver, setNodeRef } = useDroppable({ id: column.id });
   const [adding, setAdding] = useState(false);
   const [draft, setDraft] = useState('');
+  const [renaming, setRenaming] = useState(false);
+  const [nameDraft, setNameDraft] = useState(column.name);
+  const renameInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!renaming) setNameDraft(column.name);
+  }, [column.name, renaming]);
+
+  useEffect(() => {
+    if (renaming) {
+      renameInputRef.current?.focus();
+      renameInputRef.current?.select();
+    }
+  }, [renaming]);
+
+  const commitRename = () => {
+    const next = nameDraft.trim();
+    if (next && next !== column.name && onRename) {
+      onRename(column.id, next);
+    } else {
+      setNameDraft(column.name);
+    }
+    setRenaming(false);
+  };
+  const cancelRename = () => {
+    setNameDraft(column.name);
+    setRenaming(false);
+  };
 
   useEffect(() => {
     if (autoOpen) {
@@ -60,9 +91,34 @@ export function Column({
       */}
       <header className="flex items-center justify-between border-b border-line/60 px-3 py-2.5">
         <div className="flex items-center gap-2">
-          <h2 className="font-display text-2xs font-semibold uppercase tracking-wider text-soft">
-            {column.name}
-          </h2>
+          {renaming ? (
+            <input
+              ref={renameInputRef}
+              value={nameDraft}
+              onChange={(e) => setNameDraft(e.target.value)}
+              onBlur={commitRename}
+              onKeyDown={(e) => {
+                e.stopPropagation();
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  commitRename();
+                } else if (e.key === 'Escape') {
+                  e.preventDefault();
+                  cancelRename();
+                }
+              }}
+              data-testid="column-rename-input"
+              className="bg-canvas font-display text-2xs font-semibold uppercase tracking-wider text-ink outline-none ring-1 ring-accent/35 rounded-sm px-1 -mx-1"
+            />
+          ) : (
+            <h2
+              className="font-display text-2xs font-semibold uppercase tracking-wider text-soft"
+              onDoubleClick={() => onRename && setRenaming(true)}
+              title={onRename ? 'Double-click to rename' : undefined}
+            >
+              {column.name}
+            </h2>
+          )}
           <span
             className={[
               'inline-flex h-4 min-w-[16px] items-center justify-center rounded-xs px-1 font-mono text-2xs',

--- a/packages/artifact/src/hooks/useConfig.ts
+++ b/packages/artifact/src/hooks/useConfig.ts
@@ -1,5 +1,5 @@
-import { useEffect, useState } from 'react';
-import type { Config } from '../types';
+import { useCallback, useEffect, useState } from 'react';
+import type { Board, Column, Config } from '../types';
 import { api } from '../api';
 
 const FALLBACK_CONFIG: Config = {
@@ -21,7 +21,31 @@ const FALLBACK_CONFIG: Config = {
   ],
 };
 
-export function useConfig(): Config {
+function slugify(name: string): string {
+  return (
+    name
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 32) || `col-${Date.now().toString(36)}`
+  );
+}
+
+export interface ConfigApi {
+  config: Config;
+  /** Rename a column on the active board. Persists best-effort. */
+  renameColumn: (columnId: string, name: string) => void;
+  /** Append a new column to the active board. Persists best-effort. */
+  addColumn: (name: string) => void;
+}
+
+/**
+ * Loads the board configuration once at mount and exposes mutators that
+ * update the local copy optimistically and call MCP `update_config`.
+ * Cowork's iframe does not expose `callTool` today, so the optimistic
+ * local state is the user-visible source of truth between opens.
+ */
+export function useConfig(): ConfigApi {
   const [config, setConfig] = useState<Config>(FALLBACK_CONFIG);
 
   useEffect(() => {
@@ -31,5 +55,52 @@ export function useConfig(): Config {
       .catch(() => setConfig(FALLBACK_CONFIG));
   }, []);
 
-  return config;
+  const persist = useCallback((next: Config) => {
+    setConfig(next);
+    void api.updateConfig({ boards: next.boards });
+  }, []);
+
+  const renameColumn = useCallback(
+    (columnId: string, name: string) => {
+      const trimmed = name.trim();
+      if (!trimmed) return;
+      const next: Config = {
+        ...config,
+        boards: config.boards.map((b: Board) => ({
+          ...b,
+          columns: b.columns.map((c: Column) =>
+            c.id === columnId ? { ...c, name: trimmed } : c,
+          ),
+        })),
+      };
+      persist(next);
+    },
+    [config, persist],
+  );
+
+  const addColumn = useCallback(
+    (name: string) => {
+      const trimmed = name.trim();
+      if (!trimmed) return;
+      const board = config.boards.find((b) => b.id === config.defaultBoard) ?? config.boards[0];
+      if (!board) return;
+      let id = slugify(trimmed);
+      const taken = new Set(board.columns.map((c) => c.id));
+      let suffix = 2;
+      while (taken.has(id)) {
+        id = `${slugify(trimmed)}-${suffix++}`;
+      }
+      const newCol: Column = { id, name: trimmed, color: '#6b6a64' };
+      const next: Config = {
+        ...config,
+        boards: config.boards.map((b: Board) =>
+          b.id === board.id ? { ...b, columns: [...b.columns, newCol] } : b,
+        ),
+      };
+      persist(next);
+    },
+    [config, persist],
+  );
+
+  return { config, renameColumn, addColumn };
 }

--- a/packages/artifact/test/e2e/board.spec.ts
+++ b/packages/artifact/test/e2e/board.spec.ts
@@ -320,6 +320,60 @@ test.describe('inline title edit', () => {
   });
 });
 
+test.describe('column rename + add', () => {
+  test('double-click a column name opens an editable input', async ({ page }) => {
+    await gotoBoard(page);
+    const inboxHeader = page.locator('section[aria-label="Inbox"] h2').first();
+    await inboxHeader.dblclick();
+    await expect(page.getByTestId('column-rename-input')).toBeVisible();
+    await expect(page.getByTestId('column-rename-input')).toBeFocused();
+  });
+
+  test('Enter commits the new column name', async ({ page }) => {
+    await gotoBoard(page);
+    const inboxHeader = page.locator('section[aria-label="Inbox"] h2').first();
+    await inboxHeader.dblclick();
+    const input = page.getByTestId('column-rename-input');
+    await input.fill('Triage');
+    await input.press('Enter');
+    await expect(page.locator('section[aria-label="Triage"] h2').first()).toBeVisible();
+  });
+
+  test('Escape cancels and leaves the original name', async ({ page }) => {
+    await gotoBoard(page);
+    const inboxHeader = page.locator('section[aria-label="Inbox"] h2').first();
+    await inboxHeader.dblclick();
+    const input = page.getByTestId('column-rename-input');
+    await input.fill('Wrong name');
+    await input.press('Escape');
+    await expect(page.locator('section[aria-label="Inbox"] h2').first()).toBeVisible();
+    await expect(page.getByTestId('column-rename-input')).toBeHidden();
+  });
+
+  test('Add column button reveals an input that creates a new column', async ({ page }) => {
+    await gotoBoard(page);
+    const before = await page.locator('section[aria-label]').count();
+    await page.getByTestId('add-column-button').click();
+    const input = page.getByTestId('add-column-input');
+    await input.fill('Review');
+    await input.press('Enter');
+    await expect(page.locator('section[aria-label="Review"]')).toBeVisible();
+    const after = await page.locator('section[aria-label]').count();
+    expect(after).toBe(before + 1);
+  });
+
+  test('Esc cancels add-column without creating', async ({ page }) => {
+    await gotoBoard(page);
+    const before = await page.locator('section[aria-label]').count();
+    await page.getByTestId('add-column-button').click();
+    const input = page.getByTestId('add-column-input');
+    await input.fill('Should not exist');
+    await input.press('Escape');
+    await expect(page.getByTestId('add-column-input')).toBeHidden();
+    expect(await page.locator('section[aria-label]').count()).toBe(before);
+  });
+});
+
 test.describe('a11y', () => {
   test('column headers are <h2>', async ({ page }) => {
     await gotoBoard(page);


### PR DESCRIPTION
## Phase D

- **Rename**: double-click a column header → inline input. Enter commits, Esc cancels.
- **Add**: dashed '+ New column' pseudo-column at the right end. Click → input → Enter creates with collision-safe slug id.

Both flow through new `useConfig` mutators (renameColumn, addColumn) and `api.updateConfig`.

## Tests
5/5 new e2e tests pass.