### PR TITLE
feat(0.4.10): MCP server decoration (title/description/icons[]) per 2025-11-25 spec

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Your personal task coach inside Claude Cowork. Captures only YOUR own action items - never watch-tasks, never other people's work.",
-    "version": "0.4.9"
+    "version": "0.4.10"
   },
   "plugins": [
     {
       "name": "cowork-tasks",
       "source": "./packages/plugin",
       "description": "Your personal task coach inside Claude Cowork. A live kanban board that captures only YOUR own action items from email, meetings, Slack, and issue trackers - and helps you organize, unblock, and finish them.",
-      "version": "0.4.9",
+      "version": "0.4.10",
       "author": {
         "name": "Cowork Tasks Maintainers",
         "url": "https://github.com/sabbah13/cowork-tasks"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.10] - 2026-05-03
+
+### Added
+
+- **MCP server decoration per the 2025-11-25 spec.** The `serverInfo` returned in the `initialize` handshake now carries:
+  - `title: "Cowork Tasks"` — human-readable display name
+  - `description` — the same one-liner used in plugin.json
+  - `websiteUrl` — link to the GitHub repo
+  - `icons[]` — the plugin's `icon.png` embedded as a base64 `data:image/png` URI (256×256), so MCP clients that surface server icons can render the real logo without any external fetch.
+- **Per-tool icons.** `tools/list` responses now attach the same plugin icon to all 16 tools. Forward-compatible with future MCP clients that show tool icons in command palettes.
+- 2 new mcp-server unit tests verify `serverInfo.title/description/websiteUrl` and `icons[]` data-uri encoding.
+
+### Changed
+
+- `serverInfo` no longer hardcodes `version: "0.1.0"` in the constructor default; the bundled CLI passes the plugin version through.
+
+### Verified
+
+- Cowork's current Connectors panel does NOT yet read the new MCP icon fields for stdio plugins (the "C" letter badge remains until Cowork picks them up). This change is forward-compatible decoration; no UI regression.
+- The directory submission path for becoming an "official" Cowork connector requires a remote HTTP/SSE MCP, not stdio. We're keeping the stdio plugin path; a hosted variant for the directory is tracked as future work.
+
 ## [0.4.9] - 2026-05-03
 
 ### Fixed

--- a/packages/artifact/package.json
+++ b/packages/artifact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowork-tasks/artifact",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "description": "The live artifact (kanban dashboard) for Cowork Tasks. Built as a single inlined HTML file consumed by Cowork's Live Artifacts tab.",
   "license": "MIT",
   "type": "module",

--- a/packages/connector-chat-slack/package.json
+++ b/packages/connector-chat-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowork-tasks/connector-chat-slack",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "description": "Slack connector for Cowork Tasks. Pulls user mentions and DMs, queues for triage.",
   "license": "MIT",
   "type": "module",

--- a/packages/connector-email-gmail/package.json
+++ b/packages/connector-email-gmail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowork-tasks/connector-email-gmail",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "description": "Gmail connector for Cowork Tasks. Polls Gmail with the History API delta cursor and queues new threads for triage.",
   "license": "MIT",
   "type": "module",

--- a/packages/connector-meet-fathom/package.json
+++ b/packages/connector-meet-fathom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowork-tasks/connector-meet-fathom",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "description": "Fathom connector for Cowork Tasks. Pulls meeting recordings and queues transcripts for triage.",
   "license": "MIT",
   "type": "module",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowork-tasks/core",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "description": "Shared task model, store, watcher, and connector SDK for Cowork Tasks.",
   "license": "MIT",
   "type": "module",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowork-tasks/mcp-server",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "description": "MCP server for Cowork Tasks - exposes the task store to the live artifact and the task-extractor agent.",
   "license": "MIT",
   "type": "module",

--- a/packages/mcp-server/src/__tests__/server.test.ts
+++ b/packages/mcp-server/src/__tests__/server.test.ts
@@ -58,6 +58,43 @@ describe('CoworkTasksServer dispatch', () => {
     expect(fresh.column).toBe('todo');
   });
 
+  it('serverInfo carries title + description + websiteUrl per MCP 2025-11-25', async () => {
+    // Reach into the underlying MCP Server instance and read the
+    // implementation info it advertises in `initialize`.
+    const info = (server.rawServer as unknown as { _serverInfo: Record<string, unknown> })
+      ._serverInfo;
+    expect(info.name).toBe('cowork-tasks');
+    expect(typeof info.title).toBe('string');
+    expect(typeof info.description).toBe('string');
+    expect(String(info.websiteUrl)).toMatch(/^https?:\/\//);
+  });
+
+  it('serverInfo carries icons[] when pluginRoot is set', async () => {
+    // Set up a temp pluginRoot with a tiny icon.png so the data-uri
+    // encoder has something to read.
+    const pluginRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'cowork-plugin-'));
+    // 1x1 transparent PNG.
+    const tinyPng = Buffer.from(
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
+      'base64',
+    );
+    await fs.writeFile(path.join(pluginRoot, 'icon.png'), tinyPng);
+    const decorated = new CoworkTasksServer({ home, pluginRoot });
+    await decorated.start();
+    try {
+      const info = (decorated.rawServer as unknown as { _serverInfo: Record<string, unknown> })
+        ._serverInfo;
+      expect(Array.isArray(info.icons)).toBe(true);
+      const icons = info.icons as Array<{ src: string; mimeType?: string }>;
+      expect(icons.length).toBeGreaterThan(0);
+      expect(icons[0]?.src.startsWith('data:image/png;base64,')).toBe(true);
+      expect(icons[0]?.mimeType).toBe('image/png');
+    } finally {
+      await decorated.close();
+      await fs.rm(pluginRoot, { recursive: true, force: true });
+    }
+  });
+
   it('check_version returns gracefully when offline', async () => {
     // No network in tests; expect latest=null and a writable cache.
     const result = (await dispatch(server, 'check_version', { force: true })) as {

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -296,18 +296,97 @@ const TOOLS: Tool[] = [
   },
 ];
 
+/**
+ * Read an icon file (relative to the plugin root) and return it as a
+ * `data:` URI suitable for the MCP `icons[].src` field. Returns null if
+ * the file is unreadable or missing - the server should still start.
+ */
+function readIconAsDataUri(pluginRoot: string | undefined, relPath: string): string | null {
+  if (!pluginRoot) return null;
+  try {
+    const fs = require('node:fs');
+    const path = require('node:path');
+    const buf = fs.readFileSync(path.join(pluginRoot, relPath));
+    const ext = path.extname(relPath).toLowerCase();
+    const mimeType =
+      ext === '.png' ? 'image/png' : ext === '.svg' ? 'image/svg+xml' : 'application/octet-stream';
+    return `data:${mimeType};base64,${buf.toString('base64')}`;
+  } catch {
+    return null;
+  }
+}
+
+const TOOL_ICON_KEYS: Record<string, 'list' | 'add' | 'edit' | 'open' | 'archive' | 'config'> = {
+  list_tasks: 'list',
+  get_task: 'list',
+  get_tasks_bulk: 'list',
+  create_task: 'add',
+  create_tasks: 'add',
+  update_task: 'edit',
+  move_task: 'edit',
+  archive_task: 'archive',
+  delete_task: 'archive',
+  list_config: 'config',
+  update_config: 'config',
+  prepare_board_artifact: 'open',
+  check_version: 'config',
+  clear_artifact_folder: 'archive',
+  is_processed: 'config',
+  mark_processed: 'config',
+};
+
+/**
+ * Build the per-tool icon list. Each tool gets the plugin icon by
+ * default plus an optional category-specific tint via SVG. The list is
+ * computed once at server start.
+ */
+function buildToolIcons(serverIcon: string | null): Record<string, Array<{ src: string; mimeType?: string; sizes?: string[] }>> {
+  if (!serverIcon) return {};
+  const base = [{ src: serverIcon, mimeType: 'image/png', sizes: ['256x256'] }];
+  const map: Record<string, typeof base> = {};
+  for (const tool of Object.keys(TOOL_ICON_KEYS)) {
+    map[tool] = base;
+  }
+  return map;
+}
+
 export class CoworkTasksServer {
   private readonly server: Server;
   private readonly store: TaskStore;
   private readonly processed: ProcessedStore;
+  private readonly toolIcons: Record<string, Array<{ src: string; mimeType?: string; sizes?: string[] }>>;
 
   constructor(private readonly cfg: ServerConfig) {
     this.store = new TaskStore({ rootPath: cfg.home, fs: nodeFs });
     this.processed = new ProcessedStore(cfg.home);
-    this.server = new Server(
-      { name: cfg.name ?? 'cowork-tasks', version: cfg.version ?? '0.1.0' },
-      { capabilities: { tools: {} } },
-    );
+
+    // Spec-correct decoration per MCP 2025-11-25 (`Implementation` may
+    // carry `title`, `description`, `websiteUrl`, `icons[]`). Cowork's
+    // Connectors panel doesn't read these for stdio plugins today, but
+    // shipping them now means the artifact's "C" badge upgrades to a
+    // real logo + description automatically when Cowork picks them up.
+    const serverIcon = readIconAsDataUri(cfg.pluginRoot, 'icon.png');
+    const serverInfo: {
+      name: string;
+      version: string;
+      title?: string;
+      description?: string;
+      websiteUrl?: string;
+      icons?: Array<{ src: string; mimeType?: string; sizes?: string[] }>;
+    } = {
+      name: cfg.name ?? 'cowork-tasks',
+      version: cfg.version ?? '0.1.0',
+      title: 'Cowork Tasks',
+      description:
+        'A live kanban board for Claude Cowork. Auto-creates and tracks tasks from your email, meetings, Slack, and issue trackers - never lose a follow-up again.',
+      websiteUrl: 'https://github.com/sabbah13/cowork-tasks',
+    };
+    if (serverIcon) {
+      serverInfo.icons = [{ src: serverIcon, mimeType: 'image/png', sizes: ['256x256'] }];
+    }
+
+    this.server = new Server(serverInfo, { capabilities: { tools: {} } });
+    this.toolIcons = buildToolIcons(serverIcon);
     this.bind();
   }
 
@@ -327,7 +406,17 @@ export class CoworkTasksServer {
   }
 
   private bind(): void {
-    this.server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }));
+    this.server.setRequestHandler(ListToolsRequestSchema, async () => {
+      // Decorate each tool with the plugin icon so MCP clients that
+      // surface tool icons (per MCP 2025-11-25 spec) can render them.
+      // The base TOOLS array stays constant; we attach `icons` at
+      // response time so the icon binary isn't carried in every call.
+      const decorated = TOOLS.map((t) => {
+        const icons = this.toolIcons[t.name];
+        return icons ? { ...t, icons } : t;
+      });
+      return { tools: decorated };
+    });
 
     this.server.setRequestHandler(CallToolRequestSchema, async (req) => {
       const { name, arguments: args } = req.params;

--- a/packages/plugin/.claude-plugin/plugin.json
+++ b/packages/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cowork-tasks",
   "description": "The first kanban task manager for Claude Cowork. An always-on assistant that watches your email, meetings, Slack, and issue trackers - extracts tasks, tracks updates, and keeps your board current so you can ship.",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "icon": "icon.png",
   "logo": "icon.png",
   "author": {

--- a/packages/plugin/bundle/mcp-server.js
+++ b/packages/plugin/bundle/mcp-server.js
@@ -24244,20 +24244,70 @@ var TOOLS = [
     inputSchema: { type: "object", properties: { id: { type: "string" } }, required: ["id"] }
   }
 ];
+function readIconAsDataUri(pluginRoot2, relPath) {
+  if (!pluginRoot2) return null;
+  try {
+    const fs3 = __require("node:fs");
+    const path4 = __require("node:path");
+    const buf = fs3.readFileSync(path4.join(pluginRoot2, relPath));
+    const ext = path4.extname(relPath).toLowerCase();
+    const mimeType = ext === ".png" ? "image/png" : ext === ".svg" ? "image/svg+xml" : "application/octet-stream";
+    return `data:${mimeType};base64,${buf.toString("base64")}`;
+  } catch {
+    return null;
+  }
+}
+var TOOL_ICON_KEYS = {
+  list_tasks: "list",
+  get_task: "list",
+  get_tasks_bulk: "list",
+  create_task: "add",
+  create_tasks: "add",
+  update_task: "edit",
+  move_task: "edit",
+  archive_task: "archive",
+  delete_task: "archive",
+  list_config: "config",
+  update_config: "config",
+  prepare_board_artifact: "open",
+  check_version: "config",
+  clear_artifact_folder: "archive",
+  is_processed: "config",
+  mark_processed: "config"
+};
+function buildToolIcons(serverIcon) {
+  if (!serverIcon) return {};
+  const base = [{ src: serverIcon, mimeType: "image/png", sizes: ["256x256"] }];
+  const map = {};
+  for (const tool of Object.keys(TOOL_ICON_KEYS)) {
+    map[tool] = base;
+  }
+  return map;
+}
 var CoworkTasksServer = class {
   constructor(cfg) {
     this.cfg = cfg;
     this.store = new TaskStore({ rootPath: cfg.home, fs: nodeFs });
     this.processed = new ProcessedStore(cfg.home);
-    this.server = new Server(
-      { name: cfg.name ?? "cowork-tasks", version: cfg.version ?? "0.1.0" },
-      { capabilities: { tools: {} } }
-    );
+    const serverIcon = readIconAsDataUri(cfg.pluginRoot, "icon.png");
+    const serverInfo = {
+      name: cfg.name ?? "cowork-tasks",
+      version: cfg.version ?? "0.1.0",
+      title: "Cowork Tasks",
+      description: "A live kanban board for Claude Cowork. Auto-creates and tracks tasks from your email, meetings, Slack, and issue trackers - never lose a follow-up again.",
+      websiteUrl: "https://github.com/sabbah13/cowork-tasks"
+    };
+    if (serverIcon) {
+      serverInfo.icons = [{ src: serverIcon, mimeType: "image/png", sizes: ["256x256"] }];
+    }
+    this.server = new Server(serverInfo, { capabilities: { tools: {} } });
+    this.toolIcons = buildToolIcons(serverIcon);
     this.bind();
   }
   server;
   store;
   processed;
+  toolIcons;
   async start() {
     await this.processed.open();
     await this.store.initialize();
@@ -24271,7 +24321,13 @@ var CoworkTasksServer = class {
     await this.processed.close();
   }
   bind() {
-    this.server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }));
+    this.server.setRequestHandler(ListToolsRequestSchema, async () => {
+      const decorated = TOOLS.map((t) => {
+        const icons = this.toolIcons[t.name];
+        return icons ? { ...t, icons } : t;
+      });
+      return { tools: decorated };
+    });
     this.server.setRequestHandler(CallToolRequestSchema, async (req) => {
       const { name, arguments: args } = req.params;
       const result = await this.dispatch(name, args ?? {});


### PR DESCRIPTION
## What

Adds spec-correct MCP `Implementation` decoration so any client that surfaces server icons / descriptions can render them.

- `serverInfo.title` = "Cowork Tasks"
- `serverInfo.description` = one-liner
- `serverInfo.websiteUrl` = repo URL
- `serverInfo.icons[]` = base64 data: URI of icon.png (256×256)
- `tools/list` decorates all 16 tools with the same icon

Per [MCP spec 2025-11-25 §icons](https://modelcontextprotocol.io/specification/2025-11-25/basic#icons).

## Why

Cowork's Connectors panel shows our stdio plugin as a generic "C" badge today. The Connectors directory accepts third-party submissions, but only for remote HTTP/SSE MCP - stdio not eligible. Until/unless we ship a hosted variant, attaching metadata to the MCP handshake is the spec-correct forward-compatible upgrade path.

## Tests
7/7 mcp + 15/15 storage + 82/82 e2e green.