### PR TITLE
fix(0.4.11): sim follow-ups + skill allowlist validator

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Your personal task coach inside Claude Cowork. Captures only YOUR own action items - never watch-tasks, never other people's work.",
-    "version": "0.4.10"
+    "version": "0.4.11"
   },
   "plugins": [
     {
       "name": "cowork-tasks",
       "source": "./packages/plugin",
       "description": "Your personal task coach inside Claude Cowork. A live kanban board that captures only YOUR own action items from email, meetings, Slack, and issue trackers - and helps you organize, unblock, and finish them.",
-      "version": "0.4.10",
+      "version": "0.4.11",
       "author": {
         "name": "Cowork Tasks Maintainers",
         "url": "https://github.com/sabbah13/cowork-tasks"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.11] - 2026-05-03
+
+### Fixed (sim-2026-05-03 follow-ups)
+
+- **`clear_artifact_folder` returns structured errors.** Missing args / unsafe id / non-absolute artifactsDir / path-escape now return `{ok: false, error_code, message, details}` instead of throwing a free-form string. Skills and MCP clients can branch on `error_code` (`MISSING_ARGS`, `UNSAFE_ID`, `NOT_ABSOLUTE`, `PATH_ESCAPE`). Successful runs return `{ok: true, existed, deleted, path}`.
+- **NOT_ABSOLUTE check uses `path.isAbsolute`** instead of post-resolve startsWith — relative inputs were being silently coerced via cwd before; now they're rejected at the door.
+- **task-extractor: borderline "Your input on …" emails default to skip** unless paired with a deadline, named deliverable, or urgency signal. Adds explicit skip rules for FYI / "looping you in" / "Cc'ing you" / sender-voice status updates / calendar invitations (handled by the calendar category).
+
+### Added
+
+- **Build-time skill validator** (`packages/plugin/scripts/validate-skills.mjs`). Runs as the last step of `pnpm build`. Scans every `SKILL.md` for `mcp_tools` allowlist blocks and fails the build if any entry doesn't match `mcp__<server>__<tool>`. Prevents a v0.4.8-style ship of an effectively-dead artifact.
+- mcp-server unit test for the structured-error contract (`MISSING_ARGS` / `UNSAFE_ID` / `NOT_ABSOLUTE`). 8/8 pass.
+
 ## [0.4.10] - 2026-05-03
 
 ### Added

--- a/packages/artifact/package.json
+++ b/packages/artifact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowork-tasks/artifact",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "description": "The live artifact (kanban dashboard) for Cowork Tasks. Built as a single inlined HTML file consumed by Cowork's Live Artifacts tab.",
   "license": "MIT",
   "type": "module",

--- a/packages/connector-chat-slack/package.json
+++ b/packages/connector-chat-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowork-tasks/connector-chat-slack",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "description": "Slack connector for Cowork Tasks. Pulls user mentions and DMs, queues for triage.",
   "license": "MIT",
   "type": "module",

--- a/packages/connector-email-gmail/package.json
+++ b/packages/connector-email-gmail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowork-tasks/connector-email-gmail",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "description": "Gmail connector for Cowork Tasks. Polls Gmail with the History API delta cursor and queues new threads for triage.",
   "license": "MIT",
   "type": "module",

--- a/packages/connector-meet-fathom/package.json
+++ b/packages/connector-meet-fathom/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowork-tasks/connector-meet-fathom",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "description": "Fathom connector for Cowork Tasks. Pulls meeting recordings and queues transcripts for triage.",
   "license": "MIT",
   "type": "module",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowork-tasks/core",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "description": "Shared task model, store, watcher, and connector SDK for Cowork Tasks.",
   "license": "MIT",
   "type": "module",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cowork-tasks/mcp-server",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "description": "MCP server for Cowork Tasks - exposes the task store to the live artifact and the task-extractor agent.",
   "license": "MIT",
   "type": "module",

--- a/packages/mcp-server/src/__tests__/server.test.ts
+++ b/packages/mcp-server/src/__tests__/server.test.ts
@@ -95,6 +95,32 @@ describe('CoworkTasksServer dispatch', () => {
     }
   });
 
+  it('clear_artifact_folder returns structured errors for bad input', async () => {
+    // Missing args.
+    const noargs = (await dispatch(server, 'clear_artifact_folder', {})) as {
+      ok: boolean;
+      error_code?: string;
+    };
+    expect(noargs.ok).toBe(false);
+    expect(noargs.error_code).toBe('MISSING_ARGS');
+
+    // Unsafe id.
+    const unsafe = (await dispatch(server, 'clear_artifact_folder', {
+      artifactsDir: '/tmp/some-dir',
+      id: '../escape',
+    })) as { ok: boolean; error_code?: string };
+    expect(unsafe.ok).toBe(false);
+    expect(unsafe.error_code).toBe('UNSAFE_ID');
+
+    // Non-absolute artifactsDir.
+    const rel = (await dispatch(server, 'clear_artifact_folder', {
+      artifactsDir: 'not-absolute',
+      id: 'cowork-tasks',
+    })) as { ok: boolean; error_code?: string };
+    expect(rel.ok).toBe(false);
+    expect(rel.error_code).toBe('NOT_ABSOLUTE');
+  });
+
   it('check_version returns gracefully when offline', async () => {
     // No network in tests; expect latest=null and a writable cache.
     const result = (await dispatch(server, 'check_version', { force: true })) as {

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -494,7 +494,19 @@ export class CoworkTasksServer {
       case 'clear_artifact_folder': {
         const args = raw as { artifactsDir?: string; id?: string };
         if (!args.artifactsDir || !args.id) {
-          throw new Error('clear_artifact_folder requires artifactsDir and id');
+          // Input-validation errors return a structured result so MCP
+          // clients (and our skill) can branch on `error_code` instead
+          // of regexing a free-form string.
+          return {
+            ok: false,
+            error_code: 'MISSING_ARGS',
+            message:
+              'clear_artifact_folder requires both `artifactsDir` (absolute path) and `id` (safe slug).',
+            received: {
+              artifactsDir: args.artifactsDir ?? null,
+              id: args.id ?? null,
+            },
+          };
         }
         return this.clearArtifactFolder(args.artifactsDir, args.id);
       }
@@ -598,29 +610,47 @@ export class CoworkTasksServer {
   private async clearArtifactFolder(
     artifactsDir: string,
     id: string,
-  ): Promise<{ existed: boolean; deleted: boolean; path: string }> {
+  ): Promise<
+    | { ok: true; existed: boolean; deleted: boolean; path: string }
+    | { ok: false; error_code: string; message: string; details?: unknown }
+  > {
     if (!/^[a-z0-9][a-z0-9_-]{0,63}$/i.test(id)) {
-      throw new Error(`refusing to clear: id ${JSON.stringify(id)} is not a safe slug`);
+      return {
+        ok: false,
+        error_code: 'UNSAFE_ID',
+        message: 'id must match [a-z0-9_-] (1-64 chars, must start alphanumeric).',
+        details: { id },
+      };
     }
     const path = await import('node:path');
     const fs = await import('node:fs/promises');
+    if (!path.isAbsolute(artifactsDir)) {
+      return {
+        ok: false,
+        error_code: 'NOT_ABSOLUTE',
+        message: 'artifactsDir must be an absolute path.',
+        details: { artifactsDir },
+      };
+    }
     const resolvedDir = path.resolve(artifactsDir);
     const target = path.resolve(resolvedDir, id);
     if (!target.startsWith(resolvedDir + path.sep)) {
-      throw new Error('refusing to clear: target escapes artifactsDir');
-    }
-    if (!resolvedDir.startsWith(path.sep)) {
-      throw new Error('refusing to clear: artifactsDir must be absolute');
+      return {
+        ok: false,
+        error_code: 'PATH_ESCAPE',
+        message: 'Resolved target escapes artifactsDir; refusing to clear.',
+        details: { artifactsDir: resolvedDir, target },
+      };
     }
     let existed = false;
     try {
       await fs.access(target);
       existed = true;
     } catch {
-      return { existed: false, deleted: false, path: target };
+      return { ok: true, existed: false, deleted: false, path: target };
     }
     await fs.rm(target, { recursive: true, force: true });
-    return { existed, deleted: true, path: target };
+    return { ok: true, existed, deleted: true, path: target };
   }
 
   private async readPluginVersion(pluginRoot: string): Promise<string> {

--- a/packages/plugin/.claude-plugin/plugin.json
+++ b/packages/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cowork-tasks",
   "description": "The first kanban task manager for Claude Cowork. An always-on assistant that watches your email, meetings, Slack, and issue trackers - extracts tasks, tracks updates, and keeps your board current so you can ship.",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "icon": "icon.png",
   "logo": "icon.png",
   "author": {

--- a/packages/plugin/agents/task-extractor.md
+++ b/packages/plugin/agents/task-extractor.md
@@ -105,6 +105,20 @@ If any answer is no, `action: "skip"` with a one-line reason.
   a question for the owner). The To: line should include the owner; if
   they're only Cc/Bcc, prefer skip unless the body names them.
 - Skip threads where the owner has already replied with substance.
+- **Borderline phrasings to SKIP unless paired with a deadline or a
+  named deliverable:**
+  - "Your input on ..." / "Your thoughts on ..." / "Curious what you
+    think about ..." — these are conversational pings, not asks. They
+    become tasks only if the message also names a deadline ("by Fri"),
+    a named artifact ("review the deck"), or escalates urgency
+    ("blocking us"). A vague "let me know" with no deadline is FYI.
+  - "FYI" / "Just looping you in" / "Sharing for awareness" — always
+    skip, even when To: includes the owner.
+  - "Adding you to the thread" / "Cc'ing you" — skip; loop-in only.
+  - Status updates the sender wrote in their own voice ("Update: we
+    shipped X", "FYI we resolved Y") — skip, regardless of recipient.
+  - Calendar invitations — skip here; the calendar category handles
+    prep tasks.
 - `due` = any date the email mentions, or weekday+1 if "by Friday" /
   "by EOD".
 

--- a/packages/plugin/bundle/mcp-server.js
+++ b/packages/plugin/bundle/mcp-server.js
@@ -24403,7 +24403,15 @@ var CoworkTasksServer = class {
       case "clear_artifact_folder": {
         const args = raw;
         if (!args.artifactsDir || !args.id) {
-          throw new Error("clear_artifact_folder requires artifactsDir and id");
+          return {
+            ok: false,
+            error_code: "MISSING_ARGS",
+            message: "clear_artifact_folder requires both `artifactsDir` (absolute path) and `id` (safe slug).",
+            received: {
+              artifactsDir: args.artifactsDir ?? null,
+              id: args.id ?? null
+            }
+          };
         }
         return this.clearArtifactFolder(args.artifactsDir, args.id);
       }
@@ -24474,27 +24482,42 @@ var CoworkTasksServer = class {
    */
   async clearArtifactFolder(artifactsDir, id) {
     if (!/^[a-z0-9][a-z0-9_-]{0,63}$/i.test(id)) {
-      throw new Error(`refusing to clear: id ${JSON.stringify(id)} is not a safe slug`);
+      return {
+        ok: false,
+        error_code: "UNSAFE_ID",
+        message: "id must match [a-z0-9_-] (1-64 chars, must start alphanumeric).",
+        details: { id }
+      };
     }
     const path4 = await import("node:path");
     const fs3 = await import("node:fs/promises");
+    if (!path4.isAbsolute(artifactsDir)) {
+      return {
+        ok: false,
+        error_code: "NOT_ABSOLUTE",
+        message: "artifactsDir must be an absolute path.",
+        details: { artifactsDir }
+      };
+    }
     const resolvedDir = path4.resolve(artifactsDir);
     const target = path4.resolve(resolvedDir, id);
     if (!target.startsWith(resolvedDir + path4.sep)) {
-      throw new Error("refusing to clear: target escapes artifactsDir");
-    }
-    if (!resolvedDir.startsWith(path4.sep)) {
-      throw new Error("refusing to clear: artifactsDir must be absolute");
+      return {
+        ok: false,
+        error_code: "PATH_ESCAPE",
+        message: "Resolved target escapes artifactsDir; refusing to clear.",
+        details: { artifactsDir: resolvedDir, target }
+      };
     }
     let existed = false;
     try {
       await fs3.access(target);
       existed = true;
     } catch {
-      return { existed: false, deleted: false, path: target };
+      return { ok: true, existed: false, deleted: false, path: target };
     }
     await fs3.rm(target, { recursive: true, force: true });
-    return { existed, deleted: true, path: target };
+    return { ok: true, existed, deleted: true, path: target };
   }
   async readPluginVersion(pluginRoot2) {
     const fs3 = await import("node:fs/promises");

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "build": "node ./scripts/build-bundles.mjs && node ./scripts/sync-artifact.mjs",
+    "build": "node ./scripts/build-bundles.mjs && node ./scripts/sync-artifact.mjs && node ./scripts/validate-skills.mjs",
     "test": "vitest run --passWithNoTests",
     "typecheck": "echo '(no TS to check; plugin is JS + JSON)'"
   },

--- a/packages/plugin/scripts/validate-skills.mjs
+++ b/packages/plugin/scripts/validate-skills.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+/**
+ * Build-time validator for plugin assets that have wire-format
+ * requirements Cowork enforces silently.
+ *
+ * Currently checks:
+ *   - mcp_tools allowlist entries in skills/open-board/SKILL.md must
+ *     all match `mcp__<server>__<tool>`. Any other shape gets dropped
+ *     by Cowork at create_artifact time, leaving the artifact unable
+ *     to call any MCP tool. v0.4.8 shipped with `<server>:<tool>` and
+ *     was effectively dead on arrival; this guard prevents a repeat.
+ *
+ * Exit code 0 = ok. Anything else = fatal (build fails).
+ */
+import { promises as fs } from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const pluginDir = path.resolve(here, '..');
+const skillsDir = path.join(pluginDir, 'skills');
+
+const MCP_TOOL_RE = /^mcp__[a-z0-9_-]+__[a-z0-9_-]+$/i;
+
+let problems = 0;
+function fail(msg) {
+  problems += 1;
+  process.stderr.write(`[validate-skills] ${msg}\n`);
+}
+
+async function* walkSkillFiles(dir) {
+  for (const entry of await fs.readdir(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) yield* walkSkillFiles(full);
+    else if (entry.name === 'SKILL.md') yield full;
+  }
+}
+
+/**
+ * Find any code-block JSON containing an `mcp_tools` array and validate
+ * each entry's wire-format. We parse loosely (no full markdown parser):
+ * locate `"mcp_tools": [`, capture lines until the matching `]`, then
+ * extract quoted strings. Good enough for the prescribed format the
+ * skill uses; if the skill ever uses YAML or another shape, this needs
+ * updating.
+ */
+async function checkMcpToolsAllowlist(file) {
+  const text = await fs.readFile(file, 'utf-8');
+  const re = /"mcp_tools"\s*:\s*\[([\s\S]*?)\]/g;
+  let m;
+  let blocks = 0;
+  while ((m = re.exec(text)) !== null) {
+    blocks += 1;
+    const block = m[1];
+    const entries = [...block.matchAll(/"([^"]+)"/g)].map((e) => e[1]);
+    if (entries.length === 0) {
+      fail(`${path.relative(pluginDir, file)}: empty mcp_tools allowlist`);
+      continue;
+    }
+    for (const entry of entries) {
+      if (!MCP_TOOL_RE.test(entry)) {
+        fail(
+          `${path.relative(
+            pluginDir,
+            file,
+          )}: mcp_tools entry "${entry}" must match mcp__<server>__<tool>`,
+        );
+      }
+    }
+  }
+  return blocks;
+}
+
+const targets = [];
+for await (const f of walkSkillFiles(skillsDir)) targets.push(f);
+let totalBlocks = 0;
+for (const f of targets) totalBlocks += await checkMcpToolsAllowlist(f);
+
+if (problems > 0) {
+  process.stderr.write(
+    `[validate-skills] ${problems} problem(s) in ${targets.length} skill file(s). Failing.\n`,
+  );
+  process.exit(1);
+}
+
+process.stdout.write(
+  `[validate-skills] ${targets.length} skills checked, ${totalBlocks} mcp_tools block(s) ok.\n`,
+);


### PR DESCRIPTION
## Three sim-2026-05-03 follow-ups + a CI guard

### 1. Structured errors on `clear_artifact_folder`
Returns `{ok: false, error_code, message, details}` for MISSING_ARGS / UNSAFE_ID / NOT_ABSOLUTE / PATH_ESCAPE. Skills can branch on `error_code`.

### 2. Tighten task-extractor borderline rules
Borderline "Your input on …" emails default to skip unless paired with deadline / deliverable / urgency. FYI / loop-in / Cc / status-update / calendar-invite patterns explicitly skip.

### 3. Build-time skill validator
`scripts/validate-skills.mjs` scans every `SKILL.md` for `mcp_tools` blocks; fails the build if any entry doesn't match `mcp__<server>__<tool>`. Wired into `pnpm build`. Prevents v0.4.8-style regressions.

## Tests
8/8 mcp + 15/15 storage + 82/82 e2e. New unit covers structured-error contract.